### PR TITLE
Globbing asset files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ javascripts:
   package_1:
     - jquery/jquery
     - underscore
+    - plugins/jquery.*
   package_2:
     - front_page
 stylesheets:

--- a/lib/smart_asset.rb
+++ b/lib/smart_asset.rb
@@ -221,7 +221,7 @@ class SmartAsset
         host = @asset_host
       end
       
-      if host    
+      if host
         if !@asset_counter || @asset_counter == @config['asset_host_count']
           @asset_counter = 0
         end
@@ -231,7 +231,7 @@ class SmartAsset
       
         host.gsub('%d', count) + path
       else
-        path
+        "/#{path}"
       end
     end
     

--- a/lib/smart_asset.rb
+++ b/lib/smart_asset.rb
@@ -206,8 +206,7 @@ class SmartAsset
         result = @config[type].collect do |package, files|
           if package.to_s == match
             files.collect do |file|
-              file = "/#{@sources[type]}/#{file}.#{ext}"
-              file if File.exists?("#{@pub}/#{file}")
+              Dir.chdir(@pub) { Dir["#{@sources[type]}/#{file}.#{ext}"] }
             end
           end
         end

--- a/lib/smart_asset/version.rb
+++ b/lib/smart_asset/version.rb
@@ -1,3 +1,3 @@
 class SmartAsset
-  VERSION = "0.5.4" unless defined?(::SmartAsset::VERSION)
+  VERSION = "0.5.4.1"
 end


### PR DESCRIPTION
Hi,

I've made a small patch for using wildcards in asset filenames. For example, `plugins/jquery.*` can be used to load all the jquery plugins in the `plugins` directory.
