### PR TITLE
exits with status code from YUI or Google Compiler in the case of an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ You may use environment variables with the <code>smart\_asset</code> command to 
 
 <code>WARN=1</code><br/>Get compression warnings from Closure Compiler and YUI Compressor
 
+<code>STOP_ON_ERROR=1</code><br/>smart_asset will exit if Closure Compiler or YUI Compressor return a non-zero exit code.
+
 #### Example:
 
 <pre>

--- a/lib/smart_asset.rb
+++ b/lib/smart_asset.rb
@@ -101,7 +101,7 @@ class SmartAsset
             puts cmd if ENV['DEBUG']
             `#{cmd}`
 
-            if ENV['STOP_ON_ERROR'] and $?.exitstatus !== 0
+            if ENV['STOP_ON_ERROR'] and $?.exitstatus != 0
               exit!($?.exitstatus)
             end
 

--- a/lib/smart_asset.rb
+++ b/lib/smart_asset.rb
@@ -100,6 +100,11 @@ class SmartAsset
             end
             puts cmd if ENV['DEBUG']
             `#{cmd}`
+
+            if ENV['STOP_ON_ERROR'] and $?.exitstatus !== 0
+              exit!($?.exitstatus)
+            end
+
             FileUtils.rm(tmp) unless ENV['DEBUG']
             
             # Fix YUI compression issue

--- a/lib/smart_asset/version.rb
+++ b/lib/smart_asset/version.rb
@@ -1,3 +1,3 @@
 class SmartAsset
-  VERSION = "0.5.4" unless defined?(::SmartAsset::VERSION)
+  VERSION = "0.5.5" unless defined?(::SmartAsset::VERSION)
 end


### PR DESCRIPTION
I've made this opt in, but I really feel it should be the default in time.

Many build tools rely on non-zero exit status as a way of indicating an error.

Also I had to patch the spec file since it the warning[1] it was throwing were causing my rails app to not boot.

[1] smart_asset.gemspec:10: warning: toplevel constant VERSION referenced by SmartAsset::VERSION
